### PR TITLE
Combine coverage reports in makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,11 @@ test-contrib: python-version
 python-version:
 	@python --version
 
-coverage: coverage-core coverage-contrib
+coverage: coverage-core coverage-contrib coverage-report
+
+coverage-report:
+	@${COV_PROG} combine .coverage opentimelineio_contrib/adapters/.coverage
+	@${COV_PROG} report -m
 
 coverage-core: python-version
 ifndef COV_PROG
@@ -37,7 +41,6 @@ ifndef COV_PROG
 		"https://coverage.readthedocs.io/en/coverage-4.2/install.html")
 endif
 	@${COV_PROG} run --source=opentimelineio -m unittest discover tests
-	@${COV_PROG} report -m
 
 coverage-contrib: python-version
 	@make -C opentimelineio_contrib/adapters coverage VERBOSE=$(VERBOSE)

--- a/opentimelineio_contrib/adapters/Makefile
+++ b/opentimelineio_contrib/adapters/Makefile
@@ -12,12 +12,13 @@ endif
 test:
 	@python -m unittest discover tests $(TEST_ARGS)
 
+# echo "run coverage-report to see coverage report for just the contrib."
 coverage:
 ifndef COV_PROG
 	$(error "coverage is not available please see: "\
 		"https://coverage.readthedocs.io/en/coverage-4.2/install.html")
 endif
 	@${COV_PROG} run -m unittest discover tests
+
+coverage-report: coverage
 	@${COV_PROG} report -m
-
-

--- a/opentimelineio_contrib/adapters/Makefile
+++ b/opentimelineio_contrib/adapters/Makefile
@@ -12,7 +12,6 @@ endif
 test:
 	@python -m unittest discover tests $(TEST_ARGS)
 
-# echo "run coverage-report to see coverage report for just the contrib."
 coverage:
 ifndef COV_PROG
 	$(error "coverage is not available please see: "\


### PR DESCRIPTION
I noticed that it was (I think) only reading coverage from the contrib area - this PR adds some juice to the makefile to combine the coverage reports for the contrib and main library so that the coverage report includes (I think) everything.  Want to take a look and see how that works?

We've configured the coverage.io opentimelineio repo btw.